### PR TITLE
Fix typo in Suboperand docstring

### DIFF
--- a/src/pyarithmeticlib/expression.py
+++ b/src/pyarithmeticlib/expression.py
@@ -119,8 +119,8 @@ class Suboperand(Operand):
 
         :Example:
             >>> operand = Addition(Number(1), Number(5))
-            >>> suboprand = Suboperand(operand)
-            >>> print(suboprand)
+            >>> suboperand = Suboperand(operand)
+            >>> print(suboperand)
             (1 + 5)
         """
 


### PR DESCRIPTION
## Summary
- fix `Suboperand` docs to use `suboperand`

## Testing
- `PYTHONPATH=$PWD/src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f67219cec8333add041d3c75f5034