### PR TITLE
Fix duplicate Number test name

### DIFF
--- a/tests/test_expression.py
+++ b/tests/test_expression.py
@@ -58,10 +58,10 @@ test_values = [
 
 
 @pytest.mark.parametrize('number, expected', test_values)
-def test_number_evaluate(number, expected):
+def test_number_str(number, expected):
 
-    actual = number.evaluate()
-    assert str(actual) == expected
+    actual = str(number)
+    assert actual == expected
 
 # test Addition
 


### PR DESCRIPTION
## Summary
- fix duplicate name in `tests/test_expression.py`
- run `str(number)` in new `test_number_str`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pyarithmeticlib')*

------
https://chatgpt.com/codex/tasks/task_e_683f675f7b9c8333a0ecbcb25671586a